### PR TITLE
Config file correction

### DIFF
--- a/book/i18n-selecting-application-language.md
+++ b/book/i18n-selecting-application-language.md
@@ -64,7 +64,7 @@ In order to use the component you should specify it in the application config li
 return [
     'bootstrap' => [
         [
-            'class' => app\components\LanguageSelector::className(),
+            'class' => 'app\components\LanguageSelector',
             'supportedLanguages' => ['en_US', 'ru_RU'],
         ],
     ],
@@ -174,7 +174,7 @@ return [
     'components' => [
         'urlManager' => [
            'ruleConfig' => [
-                'class' => app\components\LanguageUrlRule::className()
+                'class' => 'app\components\LanguageUrlRule'
             ],
         ],
     ],


### PR DESCRIPTION
@samdark
app\components\LanguageSelector::className() и app\components\LanguageUrlRule::className() не сработают, потому что алиас @app добавляется уже после загрузки файла конфигурации - при создании yii\web\Application. Но даже если бы алиас уже был - тогда надо добавлять наследование класса LanguageSelector от \yii\base\Object.